### PR TITLE
fix(deps): lock the DA into terraform version 1.10.5

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,14 +15,14 @@ repository:
   # By changing this field, you rename the repository.
 
   # Uncomment this name property and set the name to the current repo name.
-  # name: ""
+  name: "terraform-ibm-ocp-terraform-enterprise"
 
   # The description is displayed under the repository name on the
   # organization page and in the 'About' section of the repository.
 
   # Uncomment this description property
   # and update the description to the current repo description.
-  # description: ""
+  description: "This repository provides a top-level Terraform module for deploying and managing HashiCorp Terraform Enterprise (TFE) on IBM Cloud Red Hat OpenShift clusters."
 
   # Use a comma-separated list of topics to set on the repo (ensure not to use any caps in the topic string).
-  topics: terraform, ibm-cloud, terraform-module
+  topics: terraform, ibm-cloud, terraform-module, core-team, tfe, terraform

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -319,7 +319,7 @@
               "virtual": false
             }
           ],
-          "terraform_version": "",
+          "terraform_version": "1.10.5",
           "outputs": [
             {
               "key": "tfe_console_url",


### PR DESCRIPTION

        This PR ensures that the `ibm_catalog.json` file includes the required `terraform_version` field.

        An upcoming version of **`common-dev-assets`** will introduce an updated `pre-commit` hook that enforces this check. Applying this change now ensures compatibility with the new hook and avoids future commit failures.
        