### PR TITLE
fix: extend tests, upgrade and schematics

### DIFF
--- a/modules/tfe-install/main.tf
+++ b/modules/tfe-install/main.tf
@@ -7,6 +7,13 @@ resource "kubernetes_namespace" "tfe" {
   metadata {
     name = var.namespace
   }
+
+  # Ignore annotations that TFE may add to namespace
+  lifecycle {
+    ignore_changes = [
+      metadata["annotations"],
+    ]
+  }
 }
 
 resource "kubernetes_secret" "tfe_pull_secret" {
@@ -393,8 +400,15 @@ resource "kubernetes_secret" "tfe_admin_token" {
     )
   }
   type = "Opaque"
-}
 
+  # Ignore data token, if it exists, the data.kubernetes_secret is unknown at apply
+  # It has just be read from the secret... so no need to write it.
+  lifecycle {
+    ignore_changes = [
+      data["token"],
+    ]
+  }
+}
 
 # Use scrupt to create TFE organization
 # This is a workaround to avoid using the TFE provider which attempt to evaluate the token and host before the deployment is created

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -21,7 +21,7 @@ const resourceGroup = "geretain-test-tfe"
 
 // Ensure every example directory has a corresponding test
 const completeExampleDir = "examples/complete"
-const solutionTerraformDir = "solutions/demo"
+const solutionTerraformDir = "solutions/self-hosted"
 
 // Define a struct with fields that match the structure of the YAML data
 const yamlLocation = "../common-dev-assets/common-go-assets/common-permanent-resources.yaml"
@@ -53,13 +53,6 @@ func TestMain(m *testing.M) {
 		log.Fatal(setPassEnvErr)
 	}
 
-	// NOTE: SHOULD REMOVE THIS WHEN PROJECT IS MORE STABLE
-	// While in Alpha phase we want to debug failures
-	setDoNotDestroyErr := os.Setenv("DO_NOT_DESTROY_ON_FAILURE", "true")
-	if setDoNotDestroyErr != nil {
-		log.Fatal(setDoNotDestroyErr)
-	}
-
 	os.Exit(m.Run())
 }
 
@@ -77,22 +70,10 @@ func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptio
 			"tfe_license_secret_crn":       permanentResources["terraform_enterprise_license_secret_crn"],
 			"secrets_manager_crn":          permanentResources["secretsManagerCRN"],
 		},
-		IgnoreUpdates: testhelper.Exemptions{ // Ignore for consistency check
-			List: []string{
-				"module.tfe.module.tfe_install.helm_release.tfe_install",
-				"module.tfe.module.tfe_install.kubernetes_namespace.tfe",
-				"module.tfe.module.tfe_install.kubernetes_secret.tfe_admin_token",
-			},
-		},
 	})
 
 	// NOTE ON INPUT VARS:
 	// the inputs for password are added in TestMain in the ENV.
-
-	// NOTE ON IGNORE UPDATES:
-	// In early Alpha state the helm chart and other kubernetes resources are going to
-	// report update-in-place on each run. Ignoring for now, should investigate before an
-	// official GA release.
 
 	return options
 }
@@ -145,19 +126,7 @@ func TestRunSelfHostedSchematics(t *testing.T) {
 		ResourceGroup:          resourceGroup,
 		DeleteWorkspaceOnFail:  false,
 		WaitJobCompleteMinutes: 120,
-		IgnoreUpdates: testhelper.Exemptions{ // Ignore for consistency check
-			List: []string{
-				"module.tfe.module.tfe_install.helm_release.tfe_install",
-				"module.tfe.module.tfe_install.kubernetes_namespace.tfe",
-				"module.tfe.module.tfe_install.kubernetes_secret.tfe_admin_token",
-			},
-		},
 	})
-
-	// NOTE ON IGNORE UPDATES:
-	// In early Alpha state the helm chart and other kubernetes resources are going to
-	// report update-in-place on each run. Ignoring for now, should investigate before an
-	// official GA release.
 
 	// generate a random password, fail if error
 	password, passwordErr := getRandomAdminPassword()


### PR DESCRIPTION
### Description

Test improvements, specifically adding upgrade test, schematics test and moving the license key into secrets manager.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
